### PR TITLE
Fixes #3 Add TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,19 @@ our codebase.
 
 ## How do I use it?
 
-```
+```js
 var chai = require('chai');
 
 chai.use(require('@silvermine/chai-strictly-equal'));
+```
+
+Or, if you are using TypeScript:
+
+```typescript
+import chai from 'chai';
+import enableStrictlyEqual from '@silvermine/chai-strictly-equal';
+
+chai.use(enableStrictlyEqual);
 ```
 
 That's all there is to it. Then your `.equal` calls will throw an error, indicating that

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Chai assertion library plugin to add `strictlyEqual` function and disable `equal`",
   "main": "src/index.js",
+  "types": "./types/index.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/istanbul cover --root src --include-all-sources ./node_modules/.bin/_mocha -- -R spec 'tests/**/*.test.js'"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+declare global {
+   export namespace Chai {
+      export interface Assertion {
+         strictlyEqual(value: any, message?: string): void;
+      }
+   }
+}
+
+declare const enableStrictlyEqual: (chai: any, util: any) => void;
+
+export = enableStrictlyEqual;


### PR DESCRIPTION
Add TypeScript types for the exported plugin function used to enable the
`strictlyEqual` assertion, and augment Chai's Assertion interface with
the `strictlyEqual` method.